### PR TITLE
[#ERNEST-1947] : Datacenter creation commands normalization

### DIFF
--- a/manager_datacenter.go
+++ b/manager_datacenter.go
@@ -6,8 +6,6 @@ package main
 
 import (
 	"encoding/json"
-
-	"github.com/fatih/color"
 )
 
 // Datacenter ...
@@ -30,12 +28,11 @@ func (m *Manager) CreateVcloudDatacenter(token string, name string, rtype string
 	body, res, err := m.doRequest("/api/datacenters/", "POST", payload, token, "")
 	if err != nil {
 		if res.StatusCode == 409 {
-			return "Datacenter name already in use", err
+			return "Datacenter '" + name + "' already exists, please specify a different name", err
 		} else {
 			return body, err
 		}
 	}
-	color.Green("SUCCESS: Datacenter " + name + " created")
 	return body, err
 }
 
@@ -45,12 +42,11 @@ func (m *Manager) CreateAWSDatacenter(token string, name string, rtype string, r
 	body, res, err := m.doRequest("/api/datacenters/", "POST", payload, token, "")
 	if err != nil {
 		if res.StatusCode == 409 {
-			return "Datacenter name already in use", err
+			return "Datacenter '" + name + "' already exists, please specify a different name", err
 		} else {
 			return body, err
 		}
 	}
-	color.Green("SUCCESS: Datacenter " + name + " created")
 	return body, err
 }
 

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,9 @@ package main
 import (
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"math/big"
 	"unicode"
@@ -109,4 +111,27 @@ func randString(n int) string {
 		bs[i] = byte(g.Int64())
 	}
 	return string(bs)
+}
+
+type DatacenterTemplate struct {
+	URL      string `yaml:"vcloud-url"`
+	Network  string `yaml:"public-network"`
+	Org      string `yaml:"org"`
+	Password string `yaml:"password"`
+	User     string `yaml:"user"`
+	Token    string `yaml:"token"`
+	Secret   string `yaml:"secret"`
+	Region   string `yaml:"region"`
+	Fake     bool   `yaml:"fake"`
+}
+
+func getDatacenterTemplate(template string, t *DatacenterTemplate) (err error) {
+	payload, err := ioutil.ReadFile(template)
+	if err != nil {
+		return errors.New("Template file '" + template + "' not found")
+	}
+	if yaml.Unmarshal(payload, &t) != nil {
+		return errors.New("Template file '" + template + "' is not valid yaml file")
+	}
+	return err
 }


### PR DESCRIPTION
This pull request changes the way vcloud datacenters are created. From this point they will be created the same way aws ones are created.

Every creation option has been moved to a tag, so you'll be creating aws datacenters like:
```
$ ernest-cli datacenter create aws --help
NAME:
   ernest datacenter create aws - Create a new aws datacenter.

USAGE:
   ernest datacenter create aws [command options] <datacenter-name>

DESCRIPTION:
   Create a new AWS datacenter on the targeted instance of Ernest.

  Example:
   $ ernest datacenter create aws --region region --token token --secret secret my_datacenter

   Template example:
    $ ernest datacenter create aws --template mydatacenter.yml mydatacenter
    Where mydatacenter.yaml will look like:
      ---
      fake: true
      token: token
      secret: secret
      region: region


OPTIONS:
   --region value    Datacenter region
   --token value     AWS Token
   --secret value    AWS Secret
   --template value  Datacenter template
   --fake            Fake datacenter
```

And VCloud ones like:
```
NAME:
   ernest datacenter create vcloud - Create a new vcloud datacenter.

USAGE:
   ernest datacenter create vcloud [command options] <datacenter-name>

DESCRIPTION:
   Create a new vcloud datacenter on the targeted instance of Ernest.

   Example:
    $ ernest datacenter create vcloud --user username --password xxxx --org MY-ORG-NAME --vse-url http://vse.url --vcloud-url https://myernest.com --public-network MY-PUBLIC-NETWORK mydatacenter

   Template example:
    $ ernest datacenter create vcloud --template mydatacenter.yml mydatacenter
    Where mydatacenter.yaml will look like:
      ---
      fake: true
      org: org
      password: pwd
      public-network: MY-NETWORK
      user: bla
      vcloud-url: "http://ss.com"
      vse-url: "http://ss.com"



OPTIONS:
   --user value            Your VCloud valid user name
   --password value        Your VCloud valid password
   --org value             Your vCloud Organization
   --vse-url value         VSE URL
   --vcloud-url value      VCloud URL
   --public-network value  Public Network
   --template value        Datacenter template
   --fake                  Fake datacenter
```

As you can see on the inline help we've already added support for datacenter creation based on templates, so you don't need to type all that flags on each command ;)