### PR TITLE
Expose logger preferences to admin users

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 machine:
   pre:
     - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
+    - touch /tmp/ernest.log && chmod 666 /tmp/ernest.log
   services:
     - docker
   environment:
@@ -10,12 +11,14 @@ machine:
     CURRENT_INSTANCE: http://ernest.local:80/
     JWT_SECRET: test
     IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+    ERNEST_LOG_FILE: '/tmp/ernest.log'
 
   hosts:
     ernest.local: 127.0.0.1
 
 dependencies:
   override:
+    - touch $ERNEST_LOG_FILE && chmod 777 $ERNEST_LOG_FILE
     - mkdir -p "$GOPATH/src/$IMPORT_PATH"
     - rsync -azC --delete ./ "$GOPATH/src/$IMPORT_PATH/"
     - make deps

--- a/datacenter_list_view.go
+++ b/datacenter_list_view.go
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package main
 
 import (

--- a/definition.yml
+++ b/definition.yml
@@ -13,7 +13,7 @@ repos:
 
   - name: api-gateway
     path: git@github.com:ernestio/api-gateway.git
-    branch: develop
+    branch: logger
     links:
       - nats
     ports:
@@ -223,10 +223,12 @@ repos:
 
   - name: logger
     path: git@github.com:ernestio/logger.git
-    branch: develop
+    branch: basic 
     links:
       - nats
     environment:
       NATS_URI: 'nats://nats:4222'
       ERNEST_LOG_FILE: '/tmp/ernest.log'
+    volumes:
+       - /tmp/:/tmp/
 

--- a/internal/features/cli/logger_management.feature
+++ b/internal/features/cli/logger_management.feature
@@ -1,0 +1,55 @@
+@preferences @logger @logger_management
+Feature: Ernest preferences management
+
+  Scenario: Non logged logger creationg
+    Given I setup ernest with target "https://ernest.local"
+    And I logout
+    When I run ernest with "preferences logger add basic"
+    Then The output should contain "You're not allowed to perform this action, please log in"
+
+  Scenario: Logged as plain user logger creation
+    Given I setup ernest with target "https://ernest.local"
+    And I'm logged in as "usr" / "pwd"
+    When I run ernest with "preferences logger add basic --logfile /tmp/ernest.log"
+    Then The output should contain "You're not allowed to perform this action, please log in"
+
+  Scenario: Logged as admin user basic logger creation
+    Given I setup ernest with target "https://ernest.local"
+    And I'm logged in as "ci_admin" / "pwd"
+    And File "/tmp/ernest.log" exists
+    When I run ernest with "preferences logger add basic"
+    Then The output should contain "You should specify a logfile with --logfile flag"
+    When I run ernest with "preferences logger add basic --logfile /tmp/unexisting.log"
+    Then The output should contain "Specified file '/tmp/unexisting.log' does not exist"
+    When I run ernest with "preferences logger add basic --logfile /tmp/ernest.log"
+    Then The output should contain "Logger successfully set up"
+    When I run ernest with "preferences logger list"
+    Then The output should contain "Basic logging file configured on : /tmp/ernest.log"
+    When I run ernest with "preferences logger delete basic"
+    Then The output should contain "Logger successfully deleted"
+    When I run ernest with "preferences logger list"
+    Then The output should contain "There are no loggers created yet."
+
+  Scenario: Logged as admin user logstash logger creation
+    Given I setup ernest with target "https://ernest.local"
+    And I'm logged in as "ci_admin" / "pwd"
+    And File "/tmp/ernest.log" exists
+    When I run ernest with "preferences logger add logstash"
+    Then The output should contain "You should specify a logstash hostname  with --hostname flag"
+    When I run ernest with "preferences logger add logstash --hostname http://ernest.local/"
+    Then The output should contain "You should specify a logstash port with --port flag"
+    When I run ernest with "preferences logger add logstash --hostname http://ernest.local/ --port 210"
+    Then The output should contain "You should specify a logstash timeout with --timeout flag"
+    When I run ernest with "preferences logger add logstash --hostname http://ernest.local/ --port 210 --timeout 10"
+    Then The output should contain "Logger successfully set up"
+    When I run ernest with "preferences logger list"
+    Then The output should contain "Logstash based loggers"
+    And The output should contain "http://ernest.local/"
+    And The output should contain "210"
+    And The output should contain "10"
+    When I run ernest with "preferences logger delete logstash"
+    Then The output should contain "Logger successfully deleted"
+    When I run ernest with "preferences logger list"
+    Then The output should contain "There are no loggers created yet."
+
+

--- a/internal/features/cli/step_definitions.go
+++ b/internal/features/cli/step_definitions.go
@@ -147,6 +147,14 @@ func init() {
 		n.Request("service.set", []byte(`{"name":"`+service+`","status":"`+status+`"}`), time.Second*3)
 	})
 
+	And(`^File "(.+?)" exists$`, func(filename string) {
+		if f, err := os.Create(filename); err != nil {
+			T.Errorf("Can't create file " + filename)
+		} else {
+			f.Close()
+		}
+	})
+
 }
 
 func ernest(cmdArgs ...string) {

--- a/logger_list_view.go
+++ b/logger_list_view.go
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+a* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+func printLoggerList(loggers []Logger) {
+	if len(loggers) == 0 {
+		fmt.Println("There are no loggers created yet.")
+		return
+	}
+
+	for _, l := range loggers {
+		if l.Type == "logger" {
+			fmt.Println("")
+			fmt.Println("Logstash based loggers")
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetHeader([]string{"Hostname", "Port", "Timeout", "Region", "Url"})
+
+			port := strconv.Itoa(l.Port)
+			timeout := strconv.Itoa(l.Timeout)
+			table.Append([]string{l.Hostname, port, timeout})
+			table.Render()
+		}
+
+		if l.Type == "basic" {
+			fmt.Println("")
+			fmt.Println("Basic logging file configured on : " + l.Logfile)
+		}
+	}
+
+}

--- a/logger_list_view.go
+++ b/logger_list_view.go
@@ -19,11 +19,11 @@ func printLoggerList(loggers []Logger) {
 	}
 
 	for _, l := range loggers {
-		if l.Type == "logger" {
+		if l.Type == "logstash" {
 			fmt.Println("")
 			fmt.Println("Logstash based loggers")
 			table := tablewriter.NewWriter(os.Stdout)
-			table.SetHeader([]string{"Hostname", "Port", "Timeout", "Region", "Url"})
+			table.SetHeader([]string{"Hostname", "Port", "Timeout"})
 
 			port := strconv.Itoa(l.Port)
 			timeout := strconv.Itoa(l.Timeout)
@@ -34,6 +34,11 @@ func printLoggerList(loggers []Logger) {
 		if l.Type == "basic" {
 			fmt.Println("")
 			fmt.Println("Basic logging file configured on : " + l.Logfile)
+		}
+
+		if l.Type == "rollbar" {
+			fmt.Println("")
+			fmt.Println("Rollbar logging is active")
 		}
 	}
 

--- a/logger_model.go
+++ b/logger_model.go
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+// Logger : Representation of a logger
+type Logger struct {
+	Type     string `json:"type"`
+	Logfile  string `json:"logfile"`
+	Hostname string `json:"hostname"`
+	Port     int    `json:"port"`
+	Timeout  int    `json:"timeout"`
+}

--- a/logger_model.go
+++ b/logger_model.go
@@ -6,9 +6,11 @@ package main
 
 // Logger : Representation of a logger
 type Logger struct {
-	Type     string `json:"type"`
-	Logfile  string `json:"logfile"`
-	Hostname string `json:"hostname"`
-	Port     int    `json:"port"`
-	Timeout  int    `json:"timeout"`
+	Type        string `json:"type"`
+	Logfile     string `json:"logfile"`
+	Hostname    string `json:"hostname"`
+	Port        int    `json:"port"`
+	Timeout     int    `json:"timeout"`
+	Token       string `json:"token"`
+	Environment string `json:"environment"`
 }

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,1 @@
+This folder is intended to share logs between the container and the host

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 		CmdGroup,
 		CmdDatacenter,
 		CmdService,
+		CmdPreferences,
 	}
 	app.Run(os.Args)
 }

--- a/manager_logger.go
+++ b/manager_logger.go
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ListLoggers : Lists all active loggers
+func (m *Manager) ListLoggers(token string) (loggers []Logger, err error) {
+	body, _, err := m.doRequest("/api/loggers/", "GET", []byte(""), token, "")
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &loggers)
+	if err != nil {
+		return nil, err
+	}
+	return loggers, err
+}
+
+// SetLogger : Setup a specific loger
+func (m *Manager) SetLogger(token string, logger Logger) (err error) {
+	body, err := json.Marshal(logger)
+	if err != nil {
+		return err
+	}
+	if body, resp, err := m.doRequest("/api/loggers/", "POST", body, token, ""); err != nil {
+		if resp.StatusCode == 403 {
+			return errors.New("You're not allowed to perform this action, please log in with an admin account")
+		}
+
+		return errors.New(string(body))
+	}
+
+	return nil
+}
+
+// DelLogger : Deletes a specific loger
+func (m *Manager) DelLogger(token string, logger Logger) (err error) {
+	body, err := json.Marshal(logger)
+	if err != nil {
+		return err
+	}
+	if body, resp, err := m.doRequest("/api/loggers/"+logger.Type, "DELETE", body, token, ""); err != nil {
+		if resp.StatusCode == 403 {
+			return errors.New("You're not allowed to perform this action, please log in with an admin account")
+		}
+
+		return errors.New(string(body))
+	}
+
+	return nil
+}

--- a/preferences_cmd.go
+++ b/preferences_cmd.go
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+// CmdDatacenter subcommand
+import (
+	"github.com/fatih/color"
+	"github.com/urfave/cli"
+)
+
+// ListLoggers : Lists all loggers confured on ernest
+var ListLoggers = cli.Command{
+	Name:      "list",
+	Usage:     "Lists active loggers.",
+	ArgsUsage: " ",
+	Description: `List active loggers.
+
+   Example:
+    $ ernest preferences logger list
+	`,
+	Action: func(c *cli.Context) error {
+		m, cfg := setup(c)
+		if cfg.Token == "" {
+			color.Red("You're not allowed to perform this action, please log in")
+			return nil
+		}
+		loggers, err := m.ListLoggers(cfg.Token)
+		if err != nil {
+			color.Red(err.Error())
+			return nil
+		}
+
+		printLoggerList(loggers)
+
+		return nil
+	},
+}
+
+// SetLogger : Creates / updates a looger based on it type
+var SetLogger = cli.Command{
+	Name:      "add",
+	Usage:     "Creates / updates a logger based on its type.",
+	ArgsUsage: " ",
+	Description: `Creates / updates a logger based on its types.
+
+   Example:
+    $ ernest preferences logger add basic --logfile /tmp/ernest.log
+	`,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "logfile",
+			Usage: "Specify the path for the loging file",
+		},
+		cli.StringFlag{
+			Name:  "hostname",
+			Usage: "Logstash hostname",
+		},
+		cli.IntFlag{
+			Name:  "port",
+			Usage: "Logstash port",
+		},
+		cli.IntFlag{
+			Name:  "timeout",
+			Usage: "Logstash timeout",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		if len(c.Args()) < 1 {
+			color.Red("You should specify the logger type (basic | logstash)")
+			return nil
+		}
+
+		logger := Logger{
+			Type:     c.Args()[0],
+			Logfile:  c.String("logfile"),
+			Hostname: c.String("hostname"),
+			Port:     c.Int("port"),
+			Timeout:  c.Int("timeout"),
+		}
+		if logger.Type == "basic" {
+			if logger.Logfile == "" {
+				color.Red("You should specify a logfile with --logfile flag")
+				return nil
+			}
+		} else if logger.Type == "generic" {
+			if logger.Hostname == "" {
+				color.Red("You should specify a logstash hostname  with --hostname flag")
+				return nil
+			}
+			if logger.Port == 0 {
+				color.Red("You should specify a logstash port with --port flag")
+				return nil
+			}
+			if logger.Timeout == 0 {
+				color.Red("You should specify a logstash timeout with --timeout flag")
+				return nil
+			}
+		} else {
+			color.Red("Invalid type, valid types are basic and logstash")
+			return nil
+		}
+
+		m, cfg := setup(c)
+		if cfg.Token == "" {
+			color.Red("You're not allowed to perform this action, please log in")
+			return nil
+		}
+
+		err := m.SetLogger(cfg.Token, logger)
+		if err != nil {
+			color.Red(err.Error())
+			return nil
+		}
+
+		color.Green("Logger successfully set up")
+
+		return nil
+	},
+}
+
+// DelLogger : deletes a looger based on it type
+var DelLogger = cli.Command{
+	Name:      "delete",
+	Usage:     "Deletes a logger based on its type.",
+	ArgsUsage: " ",
+	Description: `Deletes a logger based on its types.
+
+   Example:
+    $ ernest preferences logger delete basic
+	`,
+	Action: func(c *cli.Context) error {
+		if len(c.Args()) < 1 {
+			color.Red("You should specify the logger type (basic | logstash)")
+			return nil
+		}
+
+		logger := Logger{
+			Type: c.Args()[0],
+		}
+
+		m, cfg := setup(c)
+		if cfg.Token == "" {
+			color.Red("You're not allowed to perform this action, please log in")
+			return nil
+		}
+
+		err := m.DelLogger(cfg.Token, logger)
+		if err != nil {
+			color.Red(err.Error())
+			return nil
+		}
+
+		color.Green("Logger successfully deleted")
+
+		return nil
+	},
+}
+
+// LoggerCommands : Logger related commands
+var LoggerCommands = cli.Command{
+	Name:        "logger",
+	Usage:       "Setup logger preferences.",
+	Description: "Setup ernest logger preferenres.",
+	Subcommands: []cli.Command{
+		ListLoggers,
+		SetLogger,
+		DelLogger,
+	},
+}
+
+// CmdPreferences : Preferences setup
+var CmdPreferences = cli.Command{
+	Name:  "preferences",
+	Usage: "Ernest preferences",
+	Subcommands: []cli.Command{
+		LoggerCommands,
+	},
+}


### PR DESCRIPTION
Fixes https://github.com/ernestio/ernest/issues/84 by adding management tools for different logging systems + the ability to create new ones.

All new commands have been created under preferences subcomand, so you'll be able to manage them with these commands:

Basic logger
```
# Add basic (file based) logger
$ ernest-cli preferences logger add basic --logfile /tmp/ernest.log
# Remove basic logger
$ ernest-cli preferences logger delete basic
```

Logstash based logger
```
# Add logstash based logger
$ ernest-cli preferences logger add logstash --hostname http://ernest.local/ --port 210 --timeout 10
# Remove logstash based logger
$ ernest-cli preferences logger delete logstash
```

Additionally you'll be able to list existing loggers with:
```
$ ernest-cli preferences logger list
```