### PR TITLE
Implements ernest/#325 by adding descriptive errors on 403 responses

### DIFF
--- a/command/log.go
+++ b/command/log.go
@@ -45,7 +45,7 @@ var CmdLog = cli.Command{
 		}
 
 		if err := m.SetLogger(cfg.Token, logger); err != nil {
-			color.Red("Ernest wasn't able to setup sse logger")
+			color.Red(err.Error())
 			return nil
 		}
 


### PR DESCRIPTION
Fixes https://github.com/ernestio/ernest/issues/325.

My mistake, just forgot to extend the original api error to the cli output. 

This pr should be printing `You're not allowed to perform this action, please log in with an admin account"` in case the user does not have admin credentials.